### PR TITLE
Add a script for showing inactive PRs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Some scripts used for interacting with GitHub.
 Lists issues where there have been no comments by the original author (but has
 had at least one comment) for greater than 28 days.
 
+### `inactive_pulls.rb`
+
+Lists pull requests where there have been no comments by the original author 
+(but has had at least one comment) for greater than 28 days.
+
 ## Author
 
 Copyright (c) 2017 Nick Charlton <nick@nickcharlton.net>

--- a/inactive_pulls.rb
+++ b/inactive_pulls.rb
@@ -1,0 +1,40 @@
+require "octokit"
+require "active_support/time"
+require "colored2"
+require "pry"
+
+Octokit.configure do |c|
+  c.login = "nickcharlton"
+  c.password = ENV["GITHUB_TOKEN"]
+end
+
+repo = Octokit.repo("thoughtbot/administrate")
+
+pulls = repo.rels[:pulls].get
+
+loop do
+  pulls.data.each do |pull|
+    author = pull.user.login
+    comments = pull.rels[:comments].get.data
+
+    break if comments.empty?
+
+    replies_by_author = comments.map do |i|
+      i if i.user.login == author
+    end.compact
+
+    replies_within_days = replies_by_author.select do |comment|
+      comment.created_at > 28.days.ago
+    end
+
+    if replies_within_days.none?
+      puts "Title:".underlined << " #{pull.title}"
+      puts "Last reply:".underlined << " #{comments.last.created_at}"
+      puts "URL:".underlined << " #{pull.html_url}"
+      puts
+    end
+  end
+
+  break unless pulls.rels[:next]
+  pulls = pulls.rels[:next].get
+end


### PR DESCRIPTION
* This is directly based on the issues variant, but taking `pulls`
  instead.
* PRs don't have a comments property, so instead we need to fetch them
  first.