### PR TITLE
Aggregate data on issue state.

### DIFF
--- a/inactive_issues.rb
+++ b/inactive_issues.rb
@@ -14,6 +14,7 @@ issues = repo.rels[:issues].get
 
 loop do
   issues.data.each do |issue|
+    break if issue.pull_request?
     break if issue.comments.zero?
 
     author = issue.user.login

--- a/issue_state_data.rb
+++ b/issue_state_data.rb
@@ -1,0 +1,49 @@
+require "octokit"
+require "active_support/time"
+require "colored2"
+require "pry"
+require "csv"
+
+Octokit.configure do |c|
+  c.login = "nickcharlton"
+  c.password = ENV["GITHUB_TOKEN"]
+end
+
+repo = Octokit.repo("thoughtbot/administrate")
+
+issues = repo.rels[:issues].get(query: { direction: "asc", state: "all" })
+
+date_range = (repo.created_at.to_date..Date.today)
+issue_events = date_range.map { |date| [date, 0] }.to_h
+
+issue_open_events = issue_events.dup
+issue_close_events = issue_events.dup
+
+loop do
+  issues.data.each do |issue|
+    issue_open_events[issue.created_at.to_date] += 1
+
+    if issue.closed_at
+      issue_close_events[issue.closed_at.to_date] += 1
+    end
+  end
+
+  break unless issues.rels[:next]
+  issues = issues.rels[:next].get
+end
+
+accumulated_issue_count = 0
+data = [
+  ["date", "open_event", "close_event", "total_issues"],
+]
+
+date_range.each do |date|
+  created_at_events = issue_open_events[date]
+  closed_at_events = issue_close_events[date]
+  accumulated_issue_count =
+    accumulated_issue_count + created_at_events - closed_at_events
+
+  data << [date, created_at_events, closed_at_events, accumulated_issue_count]
+end
+
+puts data.reduce([]) { |csv, row| csv << CSV.generate_line(row) }.join("")


### PR DESCRIPTION
* Pulls down issues of all states (open and closed).
* For all issues, collects the open and closed events by day.
* This results in a hash (indexed by day) of issue state events since when the
  repository was created.
* An accumulated count is created by walking through the prepared hash
  and adding up when issues are created, and then taking away when
  they're closed.
* To turn this into something reusable, it's turned into a CSV.
* This allows us to look at trends of new issues, work on closing issues
  and overall state of issues.

Run on 2017-11-29 it gives us a graph like the following (in Numbers):

![screen shot 2017-11-29 at 14 38 17](https://user-images.githubusercontent.com/11917/33386701-7f9be798-d523-11e7-9dae-16851b4a3268.png)
