### PR TITLE
Ignore PRs when looking for issues.

### DIFF
--- a/inactive_issues.rb
+++ b/inactive_issues.rb
@@ -14,6 +14,7 @@ issues = repo.rels[:issues].get
 
 loop do
   issues.data.each do |issue|
+    break if issue.pull_request?
     break if issue.comments.zero?
 
     author = issue.user.login


### PR DESCRIPTION
On GitHub, a PR is an issue but not every issue is a PR. Instead of
printing all issues, first check to see if there'a a `pull_request` key
and ignore this "issue" if it exists.